### PR TITLE
Use absolute gogs config path

### DIFF
--- a/gogs/latest.sh
+++ b/gogs/latest.sh
@@ -91,7 +91,7 @@ description "gogs"
 start on runlevel [2345]
 stop on runlevel [!2345]
 respawn
-exec su -s /bin/sh -l $USERNAME -c 'cd /opt/gogs/ && ./gogs web --config custom/conf/app.ini'
+exec su -s /bin/sh -l $USERNAME -c '/opt/gogs/gogs web --config /opt/gogs/custom/conf/app.ini'
 UPSTART
 
 # Start services


### PR DESCRIPTION
I was going to email and complain but this seemed more helpful!

# issue 1
I've been running into this config path issue in multiple locations with gogs, while trying to git push to a new gogs repo
remote: 2015/09/17 15:46:23 [W] Custom config (custom/conf/app.ini) not found, ignore this if you're running first time

By using the relative path in the ./gogs boot, it writes out the relative path in the git repo update hook for all repos it reates, which then fails when run.

Using the absolute path lets gogs update command work in git or ssh.

# issue 2
My other issue that took a bit to figure out was using the same ssh key for gogs, as your portal key, really confuses gogs:
1. fatal: 'travelingcode/homedir.git' does not appear to be a git repository
which is explain more here: http://gogs.io/docs/intro/troubleshooting.html

Not sure how to fix, but it would be nice to have that CAVEATS field in the gogs installation :)